### PR TITLE
fix: count md-example attachment references as live

### DIFF
--- a/scripts/check-comments.mjs
+++ b/scripts/check-comments.mjs
@@ -39,6 +39,10 @@ const allowed = new Map([
   ]],
   ["src/shared/markdown-utils.ts", [
     "/** Provides pure Markdown analysis shared by the browser and Worker runtimes. */",
+    "// md-example fences are rendered as live markdown by the client renderer,",
+    "// so references inside them count even though stripCodeRegions discards",
+    "// them as ordinary code regions.",
+    "// A closing fence may only be followed by spaces or tabs.",
   ]],
   ["src/worker/backup/snapshot.ts", [
     "/** Produces restorable JSON, readable Markdown, and attachment files for every backup target. */",

--- a/src/shared/markdown-utils.test.ts
+++ b/src/shared/markdown-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { extractTags } from './markdown-utils'
+import { extractAttachmentIds, extractTags } from './markdown-utils'
 
 describe('extractTags', () => {
   it('handles an unterminated inline-code marker with a mismatched trailing marker', () => {
@@ -8,5 +8,46 @@ describe('extractTags', () => {
 
   it('does not treat tags in complete inline code or fenced blocks as tags', () => {
     expect(extractTags('`#inline`\n```\n#fenced\n```\n#visible')).toEqual(['visible'])
+  })
+})
+
+describe('extractAttachmentIds', () => {
+  const idA = '01m1r8923zajxnw9y0dhs6sy8j'
+  const idB = '01m1r9qq6zb99ef3cqkjrzrn89'
+
+  it('collects plain and angle-bracket references outside code regions', () => {
+    expect(extractAttachmentIds(
+      `![a](/api/files/${idA})\n\n![b](</api/files/${idB} "t">)`,
+    )).toEqual([idA, idB])
+  })
+
+  it('ignores references inside ordinary fenced code', () => {
+    expect(extractAttachmentIds(
+      '```\n![a](/api/files/' + idA + ')\n```\n![b](/api/files/' + idB + ')',
+    )).toEqual([idB])
+  })
+
+  it('collects references inside md-example fences, which render as live markdown', () => {
+    expect(extractAttachmentIds(
+      `~~~~md-example title="Image"\n![a](</api/files/${idA} "a">)\n~~~~`,
+    )).toEqual([idA])
+  })
+
+  it('keeps stripping nested ordinary code inside an md-example fence', () => {
+    expect(extractAttachmentIds(
+      `~~~~md-example\n\`\`\`\n![a](/api/files/${idA})\n\`\`\`\n![b](/api/files/${idB})\n~~~~`,
+    )).toEqual([idB])
+  })
+
+  it('accepts the markdown-example alias', () => {
+    expect(extractAttachmentIds(
+      `~~~markdown-example\n![a](/api/files/${idA})\n~~~`,
+    )).toEqual([idA])
+  })
+
+  it('does not close an md-example fence on a marker followed by text', () => {
+    expect(extractAttachmentIds(
+      `~~~~md-example\n![a](/api/files/${idA})\n~~~~ trailing\n![b](/api/files/${idB})`,
+    )).toEqual([idB, idA])
   })
 })

--- a/src/shared/markdown-utils.ts
+++ b/src/shared/markdown-utils.ts
@@ -447,10 +447,45 @@ const ATTACHMENT_REFERENCE_RE =
 
 
 export function extractAttachmentIds(content: string): string[] {
-  const safe = stripCodeRegions(splitFrontMatter(content).body)
+  const body = splitFrontMatter(content).body
   const ids = new Set<string>()
-  for (const match of safe.matchAll(ATTACHMENT_REFERENCE_RE)) ids.add(match[1]!)
+  for (const match of stripCodeRegions(body).matchAll(ATTACHMENT_REFERENCE_RE)) ids.add(match[1]!)
+  // md-example fences are rendered as live markdown by the client renderer,
+  // so references inside them count even though stripCodeRegions discards
+  // them as ordinary code regions.
+  for (const inner of markdownExampleBodies(body)) {
+    for (const id of extractAttachmentIds(inner)) ids.add(id)
+  }
   return [...ids]
+}
+
+function markdownExampleBodies(text: string): string[] {
+  const bodies: string[] = []
+  const lines = text.split('\n')
+  let fenceChar = ''
+  let fenceLen = 0
+  let collecting: string[] | null = null
+  for (const line of lines) {
+    const fence = /^[ \t]{0,3}(`{3,}|~{3,})(.*)$/.exec(line)
+    if (fence) {
+      const marker = fence[1]!
+      if (collecting === null) {
+        if (/^\s*(?:md-example|markdown-example)\b/.test(fence[2] ?? '')) {
+          fenceChar = marker[0]!
+          fenceLen = marker.length
+          collecting = []
+        }
+      } else if (marker[0]! === fenceChar && marker.length >= fenceLen && !(fence[2] ?? '').trim()) {
+        // A closing fence may only be followed by spaces or tabs.
+        bodies.push(collecting.join('\n'))
+        collecting = null
+      }
+      continue
+    }
+    if (collecting !== null) collecting.push(line)
+  }
+  if (collecting) bodies.push(collecting.join('\n'))
+  return bodies
 }
 
 export function normalizeLinkKey(title: string): string {


### PR DESCRIPTION
## Summary

Attachments referenced inside `~~~~md-example` fences render fine in the app but break in shared notes (401)

## Description

The client renderer renders md-example fences as real markdown, so an attachment referenced only inside such a fence still produces a working <img>. extractAttachmentIds, however, strips every fenced region before scanning, so those references were invisible to the server: shared notes returned 401 for them, backups skipped the objects, and the unreferenced- attachment cleanup could delete them

## Reproduction

Sharing

```markdown
~~~~md-example title="Image"
![Image](</api/files/image-id>)
~~~~
```

will got `{"error":{"code":"unauthenticated","message":"You do not have access to this attachment"}}` when accessing the image

But

```markdown
~~~~md-example title="Image"
![Image](</api/files/same-image-id>)
~~~~

![Image](</api/files/same-image-id>)
```

will render both images in the sharing link

## Fix

`extractAttachmentIds` now additionally collects the bodies of md-example fences and extracts their references recursively, so nested ordinary code blocks inside an example are still ignored exactly as the nested render ignores them